### PR TITLE
Packaging

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,4 +13,3 @@ termcolor = "*"
 
 [dev-packages]
 "flake8" = "*"
-pyinstaller = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7f591957911653620c26dbb525ac20240e575a1f480e2bd32e215577f62d82d4"
+            "sha256": "0fdf1235974e1fac5c8aa6a677e5aecf1c2490b38422a9774c9378d43f56e479"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -33,10 +33,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
-                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+                "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
+                "sha256:fd7c7c74727ddcf00e9acd26bba8da604ffec95bf1c2144e67aff7a8b50e6cef"
             ],
-            "version": "==2019.6.16"
+            "version": "==2019.9.11"
         },
         "chardet": {
             "hashes": [
@@ -47,18 +47,18 @@
         },
         "idna": {
             "hashes": [
-                "sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e",
-                "sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
-            "version": "==2.7"
+            "version": "==2.8"
         },
         "requests": {
             "hashes": [
-                "sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54",
-                "sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263"
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "index": "pypi",
-            "version": "==2.20.1"
+            "version": "==2.22.0"
         },
         "soupsieve": {
             "hashes": [
@@ -76,41 +76,27 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
-                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
             ],
-            "index": "pypi",
-            "version": "==1.24.2"
+            "version": "==1.25.3"
         }
     },
     "develop": {
-        "altgraph": {
+        "entrypoints": {
             "hashes": [
-                "sha256:d6814989f242b2b43025cba7161fc1b8fb487a62cd49c49245d6fd01c18ac997",
-                "sha256:ddf5320017147ba7b810198e0b6619bd7b5563aa034da388cea8546b877f9b0c"
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
             ],
-            "version": "==0.16.1"
+            "version": "==0.3"
         },
         "flake8": {
             "hashes": [
-                "sha256:6a35f5b8761f45c5513e3405f110a86bea57982c3b75b766ce7b65217abe1670",
-                "sha256:c01f8a3963b3571a8e6bd7a4063359aff90749e160778e03817cd9b71c9e07d2"
+                "sha256:19241c1cbc971b9962473e4438a2ca19749a7dd002dd1a946eaba171b4114548",
+                "sha256:8e9dfa3cecb2400b3738a42c54c3043e821682b9c840b0448c0503f781130696"
             ],
             "index": "pypi",
-            "version": "==3.6.0"
-        },
-        "future": {
-            "hashes": [
-                "sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8"
-            ],
-            "version": "==0.17.1"
-        },
-        "macholib": {
-            "hashes": [
-                "sha256:ac02d29898cf66f27510d8f39e9112ae00590adb4a48ec57b25028d6962b1ae1",
-                "sha256:c4180ffc6f909bf8db6cd81cff4b6f601d575568f4d5dee148c830e9851eb9db"
-            ],
-            "version": "==1.11"
+            "version": "==3.7.8"
         },
         "mccabe": {
             "hashes": [
@@ -119,32 +105,19 @@
             ],
             "version": "==0.6.1"
         },
-        "pefile": {
-            "hashes": [
-                "sha256:a5d6e8305c6b210849b47a6174ddf9c452b2888340b8177874b862ba6c207645"
-            ],
-            "version": "==2019.4.18"
-        },
         "pycodestyle": {
             "hashes": [
-                "sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83",
-                "sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a"
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
             ],
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "pyflakes": {
             "hashes": [
-                "sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49",
-                "sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae"
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
             ],
-            "version": "==2.0.0"
-        },
-        "pyinstaller": {
-            "hashes": [
-                "sha256:a5a6e04a66abfcf8761e89a2ebad937919c6be33a7b8963e1a961b55cb35986b"
-            ],
-            "index": "pypi",
-            "version": "==3.4"
+            "version": "==2.1.1"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # focstest
+_(you can skip to [Getting Started](#getting-started))_
 
-So, you're in Olin's FoCS course and you've started to fill out the functions
-for this week's homework assignment. You're looking at the homework document and
-you find a bunch of blocks like these:
+So, you're in Olin's FoCS (Foundations of Computer Science) course and you've
+started to fill out the functions for this week's homework assignment. You're
+looking at the homework document and you find a bunch of blocks of example
+outputs like these:
 ```
 # expt 1 0;;
 - : int = 1
@@ -17,7 +19,7 @@ yourself, but this is a computer science course! There's got to be a slightly
 faster way that may or may not have taken more development time to create than
 it saved...
 
-Introducing...
+Introducing:
 ```
   __                _            _
  / _| ___   ___ ___| |_ ___  ___| |_
@@ -60,19 +62,70 @@ Just read these (mostly real) testimonials:
 
 ## Getting Started
 
+### Prerequisites
+
+You'll need Python 3.5+ and `pip`.
+
+The `ocaml` interpreter needs to be installed and on your PATH (you can run it
+from a terminal).
+
 ### Installation
 
-The python packages `BeautifulSoup`, `requests`, and `termcolor` are required. Install them with `pip install bs4 requests termcolor`, or `pipenv install`.
+#### Pip
 
-The `ocaml` interpreter needs to be installed and on your PATH.
+The recommended way to install `focstest` is through `pip`, which will install the
+necessary package requirements and add `focstest` to your terminal. You can do
+this by cloning the source repository to somewhere on your machine and running
+`pip install`:
+
+```shell
+git clone https://github.com/olin/focstest.git
+pip install focstest/
+```
+
+You should now be able to run `focstest --help` and see the
+[usage message below](#usage).
+
+#### Manual
+
+Alternatively, you can run the `focstest.py` script directly after installing
+the necessary requirements:
+
+The python packages `BeautifulSoup`, `requests`, and `termcolor` are required.
+Install them with `pip install bs4 requests termcolor`, or `pipenv install`.
 
 ### Usage
 
-`focstest` uses a standard python-powered command-line interface. You can always ask it for help with `--help` or `-h`.
+**Note/Disclaimer: `focstest` only compares the given output with your code's output.
+Generally, the FoCS examples are not exhaustive and are often more nuanced than
+a direct comparison. You'll still need to understand _what the problem is asking_
+and _whether your output makes sense_.**
+
+`focstest` works by parsing doctest-like blocks of ocaml code from a website,
+and then running them with your provided ocaml file loaded to compare the
+outputs. If you give it a homework file, it can infer the relevant webpage to
+scrape tests from:
+```
+focstest homework2.ml
+```
+but you can also give it a url directly:
+```
+focstest homework2.ml --url http://rpucella.net/courses/focs-fa19/homeworks/homework2.html
+```
+The html files are _cached locally_ to reduce the number of network requests. If
+the website has been updated with corrections or additions and you want to
+refresh `focstest`'s copy, use the `--update-cache` flag:
+```
+focstest homework2.ml --update-cache
+```
+
+
+`focstest` uses a standard python-powered command-line interface. You can always
+ask it for help with `--help` or `-h`.
 
 ```
-$ ./focstest.py --help
-usage: focstest.py [-h] [-u URL] [-v] [--log-level {debug,info,warning}] [-uc]
+$ focstest --help
+usage: focstest [-h] [-u URL] [-v] [--log-level {debug,info,warning}] [-uc]
                    [-U [N [N ...]] | -S [N [N ...]]]
                    ocaml-file
 
@@ -127,4 +180,4 @@ Run `pipenv install --dev` to install all of the dev packages.
 
 Run tests with `python -m unittest discover`.
 
-Build an executable of your own with `pyinstaller -F focstest.py`.
+Want to use it while you hack on it? Install it with `pip install -e`.

--- a/focstest.py
+++ b/focstest.py
@@ -179,10 +179,11 @@ def infer_url(filepath):
     return url
 
 
-if __name__ == "__main__":
+def main():
     parser = argparse.ArgumentParser(
         description='Run ocaml "doctests".',
         epilog='Submit bugs to <https://github.com/olin/focstest/issues/>.')
+    # parser.add_argument('--version', action='version', version='')
     input_types = parser.add_mutually_exclusive_group(required=False)
     input_types.add_argument('-u', '--url', type=str,
                              help='a url to scrape tests from (usually automagically guessed based on ocaml-file)')
@@ -318,3 +319,7 @@ if __name__ == "__main__":
         print(colored(skip_summary, 'yellow'))
     else:
         print(skip_summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/focstest.py
+++ b/focstest.py
@@ -2,6 +2,7 @@
 import argparse
 import logging
 import os
+from pkg_resources import get_distribution, DistributionNotFound
 import re
 import subprocess
 import sys
@@ -15,6 +16,15 @@ from termcolor import colored
 logger = logging.getLogger(name=__name__)  # create logger in order to change level later
 logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler())
+
+
+# get version from setuptools installation
+try:
+    __version__ = get_distribution('focstest').version
+except DistributionNotFound:
+    # not installed
+    # TODO: try git directly
+    __version__ = 'unknown, try `git describe`'
 
 
 # default url matching
@@ -183,7 +193,7 @@ def main():
     parser = argparse.ArgumentParser(
         description='Run ocaml "doctests".',
         epilog='Submit bugs to <https://github.com/olin/focstest/issues/>.')
-    # parser.add_argument('--version', action='version', version='')
+    parser.add_argument('--version', action='version', version=__version__)
     input_types = parser.add_mutually_exclusive_group(required=False)
     input_types.add_argument('-u', '--url', type=str,
                              help='a url to scrape tests from (usually automagically guessed based on ocaml-file)')

--- a/focstest.py
+++ b/focstest.py
@@ -6,6 +6,7 @@ from pkg_resources import get_distribution, DistributionNotFound
 import re
 import subprocess
 import sys
+import tempfile
 import urllib.parse
 
 from bs4 import BeautifulSoup
@@ -229,7 +230,8 @@ def main():
             URL = url_guess
 
     # get and cache webpage
-    CACHE_DIR = 'focstest-cache/'
+    temp_dir = tempfile.gettempdir()  # most likely /tmp/ on Linux
+    CACHE_DIR = os.path.join(temp_dir, 'focstest-cache')
     if not os.path.exists(CACHE_DIR):
         os.makedirs(CACHE_DIR)
         logger.info('Created cache directory at {!r}'.format(CACHE_DIR))

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+import configparser
+import setuptools
+
+
+def read_pipfile():
+    """Parses package requirements from a Pipfile.
+
+    Reformats them to match a pip-style specifier, e.g. `"bs4" = "*"` -> `bs4`,
+    and `termcolor = ">=1.23"` -> `termcolor>=1.23`.
+    """
+    pfile = configparser.ConfigParser()
+    pfile.read('Pipfile')
+    req_specifiers = []
+    for package, version in pfile['packages'].items():
+        # normalize strings, since Pipenv likes to add quotes on some things
+        package = package.strip('\'"')
+        version = version.strip('\'"')
+        spec = package + ('' if version == '*' else version)
+        req_specifiers.append(spec)
+    return req_specifiers
+
+
+req_specifiers = read_pipfile()
+
+setuptools.setup(
+    name='focstest',
+    url='https://github.com/olin/focstest/',
+    use_scm_version=True,
+    setup_requires=['setuptools_scm'],
+    # packages=setuptools.find_packages(),
+    install_requires=req_specifiers,
+    py_modules=['focstest'],
+    entry_points={
+        'console_scripts': [
+            'focstest = focstest:main',
+        ],
+    },
+)


### PR DESCRIPTION
The main goal here is to use Python's packaging system to distribute `focstest`. (closes #9)

This means that the setup process simplifies to:
1. Clone the repo.
2. Run `pip install`.


The standard method for python packing looks like the `setuptools` package.

There are a couple of things to figure out along the way:
- [x] adding the `focstest` executable to the user's PATH
- [x] list dependencies
- [x] versioning
- [x] a better location/method for the cache directory

## Adding `focstest` to PATH
`setuptools` provides a [`console_scripts` API](https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation) to install executables in a platform-agnostic way. All it needs is a function to call as an entrypoint, which in this case could just be `main()`.

## Dependencies
Currently dependencies are managed with Pipenv, so they're listed inside of the `Pipfile`. `setuptools` wants a list of dependencies specified in the format of a `requirements.txt` or the `Pipfile`'s `[packages]` section. I've used `pipenv-to-requirements` in the past for keeping a `requirements.txt` file up-to-date with the `Pipfile`, but it seems a little less than ideal.

## Versioning
Ideally this could be a quick `git describe`-linked method, still looking for a good solution.
`setuptools` offers the `use_scm_version` option, which works for installed instances but not running the script directly.

## Cache directory
`focstest` currently caches the html pages it requests indefinitely, which can be disabled with the `--update-cache` flag.

Longer term:
- This behavior should be communicated more clearly to the user, as a possible pain point is unknowingly testing against old tests that have been updated online. 
- Keeping track of the age of these files would be nice.

Right now, that directory is created in the same location the script is run from, leaving files lying around in potentially unexpected ways. Setting a standard location for the cache directory would make things less confusing for users.
The options for this that I've found are:
- Using the [`setuptools` package resource API](https://setuptools.readthedocs.io/en/latest/pkg_resources.html#resourcemanager-api), which places selected files in OS-specific directories and lets you read them back in. It seems like it supports directories, but as far as I can tell it doesn't support writing to them, only reading? Either way, it looks pretty bulky and means that `focstest` would need to be installed before you could use the cache (just running it as a script wouldn't have access to package resources).
- Using the builtin [`tempfile` library](https://docs.python.org/3.5/library/tempfile.html), which finds the best user-writable temporary directory on the system. A lot of the methods there seem geared towards temporary files/directories that only last for the duration the program is run for, but we specifically need temporary files that last _between_ runs. `tempfile.gettempdir()` returns the overall temporary directory, which could be plugged in instead of the current directory.