### PR TITLE
Add optional whitespace between command and result

### DIFF
--- a/focstest.py
+++ b/focstest.py
@@ -37,7 +37,7 @@ HTML_FILE_TEMPLATE = "homework{}.html"  # template to build the html filename gi
 CODE_BLOCK_SELECTOR = 'pre code'  # css selector to get code blocks
 
 # regex patterns for parsing text
-TEST_PATTERN = "^(.+;;)\n(.*)$"  # pattern to get input and output
+TEST_PATTERN = "^(.+;;)\s*\n(.*)$"  # pattern to get input and output
 OCAML_PATTERN = "^(.*)"  # pattern to grab output of lines
 
 # compile regexes ahead of time


### PR DESCRIPTION
[homework8](http://rpucella.net/courses/focs-fa19/homeworks/homework8.html) has extraneous spaces after the command, and focstest cannot parse it.